### PR TITLE
Remove rectangle from patient experience section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1327,24 +1327,9 @@
             overflow: hidden;
         }
 
-        .service-cta::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: -100%;
-            width: 100%;
-            height: 100%;
-            background: #2EA6D4;
-            transition: left 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-            z-index: -1;
-        }
-
         .service-cta:hover {
+            background: #2EA6D4;
             color: white;
-        }
-
-        .service-cta:hover::before {
-            left: 0;
         }
 
         .service-tier.popular .service-cta {


### PR DESCRIPTION
Remove problematic `::before` pseudo-element from `.service-cta` to fix a visual glitch causing a black rectangle.

---

[Open in Web](https://cursor.com/agents?id=bc-af35042b-56d8-4995-a5a8-025a06ad2e9d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-af35042b-56d8-4995-a5a8-025a06ad2e9d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)