### PR TITLE
Hipaa page chat widget

### DIFF
--- a/hipaa.html
+++ b/hipaa.html
@@ -4567,9 +4567,6 @@
     <div class="cursor-follower"></div>
     <div class="cursor-dot"></div>
 
-    <!-- Engagement Widget Container -->
-    <div id="engagement-widget-container" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999;"></div>
-
     <!-- Video Modal -->
     <div class="video-modal" id="videoModal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.8); z-index: 10000; align-items: center; justify-content: center;">
         <div class="video-modal-content" style="position: relative; max-width: 90%; max-height: 90%; background: black; border-radius: 10px; overflow: hidden;">
@@ -5124,34 +5121,10 @@
         });
     </script>
 
-    <!-- Start Engagement Widget Script -->
-    <script>
-        window.engagementContextExtra = {
-            // Add your custom data here
-        };
-        (function (w, i, d, g, e, t) {
-            const s = w.createElement(i);
-            d.forEach(([k, v]) => s.setAttribute(k, v));
-            w.body.appendChild(s);
-        })(
-            document,
-            'script',
-            [['async', 1],
-                ['crossorigin', 1],
-                ['type', 'module'],
-                ['id', 'engagementWidget'],
-                ['src', 'https://cdn.chatwidgets.net/widget/livechat/bundle.js'],
-                ['data-env', '//graph.mycrmsupport.net'],
-                ['data-instance', 'aIlWxNpg5fzfUZ3i'],
-                ['data-container', '#engagement-widget-container']]
-        );
-    </script>
-    <!-- End Engagement Widget Script -->
-
     <script 
         src="https://beta.leadconnectorhq.com/loader.js"  
         data-resources-url="https://beta.leadconnectorhq.com/chat-widget/loader.js" 
-        data-widget-id="689ea3f2ed32875e3b14b2f4">
+        data-widget-id="692e35e1885ff875a3542ddb">
     </script>
 </body>
 </html>


### PR DESCRIPTION
Replaced the chat widget on `hipaa.html` by removing the old engagement widget and updating the LeadConnector widget's ID to the new one provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-b51b910b-f22f-4c66-a793-5dd3b85cf531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b51b910b-f22f-4c66-a793-5dd3b85cf531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

